### PR TITLE
Update QtViewer.py

### DIFF
--- a/OCCT/Visualization/QtViewer.py
+++ b/OCCT/Visualization/QtViewer.py
@@ -73,9 +73,9 @@ class QOpenCascadeWidget(QOpenGLWidget):
         self._black = Quantity_Color(Quantity_NOC_BLACK)
 
         # Display connection
-        self.display_connection = Aspect_DisplayConnection()
+        self.display_connect = Aspect_DisplayConnection()
         # Graphics driver
-        self._graphics_driver = OpenGl_GraphicDriver(self.display_connection)
+        self._graphics_driver = OpenGl_GraphicDriver(self.display_connect)
 
         # Create viewer and view
         self.my_viewer = V3d_Viewer(self._graphics_driver)
@@ -98,7 +98,7 @@ class QOpenCascadeWidget(QOpenGLWidget):
         elif sys.platform.startswith('linux'):
             from OCCT.Xw import Xw_Window
 
-            window = Xw_Window(self.display_connection, hwnd)
+            window = Xw_Window(self.display_connect, hwnd)
         else:
             raise NotImplementedError('Support platform not found for visualization.')
 

--- a/OCCT/Visualization/QtViewer.py
+++ b/OCCT/Visualization/QtViewer.py
@@ -73,9 +73,9 @@ class QOpenCascadeWidget(QOpenGLWidget):
         self._black = Quantity_Color(Quantity_NOC_BLACK)
 
         # Display connection
-        self.display_connect = Aspect_DisplayConnection()
+        self.display_connection = Aspect_DisplayConnection()
         # Graphics driver
-        self._graphics_driver = OpenGl_GraphicDriver(self.display_connect)
+        self._graphics_driver = OpenGl_GraphicDriver(self.display_connection)
 
         # Create viewer and view
         self.my_viewer = V3d_Viewer(self._graphics_driver)


### PR DESCRIPTION
Looks like a rename or something happened, it should be `display_connection` or the linux viewer won't start.

```
OCCT/Visualization/QtViewer.py", line 100, in __init__
    window = Xw_Window(self.display_connection, hwnd)
AttributeError: 'QOpenCascadeWidget' object has no attribute 'display_connection'

```

See https://github.com/frmdstryr/pyOCCT/blob/16529ab011d427a46a9b793401c9de9e0fd042ff/OCCT/Visualization/QtViewer.py#L101
